### PR TITLE
[1단계 - 상품 관리 기능] 코코닥(이승용) 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@
     - [ ] path: "/"
 
 ## 상품 관리 CRUD API 작성
-- [ ] Create
-    - [ ] HttpMethod: POST
-    - [ ] path: "/admin/products"
-- [ ] Read
-    - [ ] HttpMethod: GET
-    - [ ] path: "/admin/products/"
-- [ ] Update
-    - [ ] HttpMethod: PATCH
-    - [ ] path: "/admin/products/{product_id}"
-- [ ] Delete
-    - [ ] HttpMethod: DELETE
-    - [ ] path: "/admin/products/{product_id}"
+- [x] Create
+    - [x] HttpMethod: POST
+    - [x] path: "/admin/products"
+- [x] Read
+    - [x] HttpMethod: GET
+    - [x] path: "/admin/products"
+- [x] Update
+    - [x] HttpMethod: PATCH
+    - [x] path: "/admin/products/{product_id}"
+- [x] Delete
+    - [x] HttpMethod: DELETE
+    - [x] path: "/admin/products/{product_id}"
 
 ## 관리자 도구 페이지 연동

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # jwp-shopping-cart
 
 ## 상품 목록 페이지 연동
-- [ ] spec
-    - [ ] HttpMethod: GET
-    - [ ] path: "/"
+- [x] spec
+    - [x] HttpMethod: GET
+    - [x] path: "/"
 
 ## 상품 관리 CRUD API 작성
 - [x] Create

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # jwp-shopping-cart
+
+## 상품 목록 페이지 연동
+- [ ] spec
+    - [ ] HttpMethod: GET
+    - [ ] path: "/"
+
+## 상품 관리 CRUD API 작성
+- [ ] Create
+    - [ ] HttpMethod: POST
+    - [ ] path: "/admin/products"
+- [ ] Read
+    - [ ] HttpMethod: GET
+    - [ ] path: "/admin/products/"
+- [ ] Update
+    - [ ] HttpMethod: PATCH
+    - [ ] path: "/admin/products/{product_id}"
+- [ ] Delete
+    - [ ] HttpMethod: DELETE
+    - [ ] path: "/admin/products/{product_id}"
+
+## 관리자 도구 페이지 연동

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:4.4.0'

--- a/src/main/java/cart/controller/AdminController.java
+++ b/src/main/java/cart/controller/AdminController.java
@@ -3,6 +3,7 @@ package cart.controller;
 import cart.dto.ProductDto;
 import cart.service.ProductManagementService;
 import java.util.List;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Controller
 public class AdminController {
@@ -22,25 +24,29 @@ public class AdminController {
     }
 
     @GetMapping(value = {"/admin", "/admin/products"})
-    public void readProducts(final Model model) {
+    @ResponseStatus(HttpStatus.OK)
+    public String readProducts(final Model model) {
         final List<ProductDto> allProduct = productManagementService.findAllProduct();
         model.addAttribute("products", allProduct);
+        return "admin";
     }
 
     @PostMapping("/admin/products")
+    @ResponseStatus(HttpStatus.CREATED)
     public void createProduct(@RequestBody final ProductDto productDto) {
         productManagementService.addProduct(productDto);
     }
 
     @PatchMapping("/admin/products/{product_id}")
+    @ResponseStatus(HttpStatus.CREATED)
     public void updateProduct(@PathVariable("product_id") final Long id, @RequestBody final ProductDto productDto) {
-        System.out.println(productDto);
         final ProductDto updatedProductDto
                 = new ProductDto(id, productDto.getName(), productDto.getImageUrl(), productDto.getPrice());
         productManagementService.updateProduct(updatedProductDto);
     }
 
     @DeleteMapping("/admin/products/{product_id}")
+    @ResponseStatus(HttpStatus.OK)
     public void deleteProduct(@PathVariable("product_id") final Long id) {
         productManagementService.deleteProduct(id);
     }

--- a/src/main/java/cart/controller/AdminController.java
+++ b/src/main/java/cart/controller/AdminController.java
@@ -1,0 +1,47 @@
+package cart.controller;
+
+import cart.dto.ProductDto;
+import cart.service.ProductManagementService;
+import java.util.List;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Controller
+public class AdminController {
+
+    private final ProductManagementService productManagementService;
+
+    public AdminController(final ProductManagementService productManagementService) {
+        this.productManagementService = productManagementService;
+    }
+
+    @GetMapping(value = {"/admin", "/admin/products"})
+    public void readProducts(final Model model) {
+        final List<ProductDto> allProduct = productManagementService.findAllProduct();
+        model.addAttribute("products", allProduct);
+    }
+
+    @PostMapping("/admin/products")
+    public void createProduct(@RequestBody final ProductDto productDto) {
+        productManagementService.addProduct(productDto);
+    }
+
+    @PatchMapping("/admin/products/{product_id}")
+    public void updateProduct(@PathVariable("product_id") final Long id, @RequestBody final ProductDto productDto) {
+        System.out.println(productDto);
+        final ProductDto updatedProductDto
+                = new ProductDto(id, productDto.getName(), productDto.getImageUrl(), productDto.getPrice());
+        productManagementService.updateProduct(updatedProductDto);
+    }
+
+    @DeleteMapping("/admin/products/{product_id}")
+    public void deleteProduct(@PathVariable("product_id") final Long id) {
+        productManagementService.deleteProduct(id);
+    }
+}

--- a/src/main/java/cart/controller/AdminController.java
+++ b/src/main/java/cart/controller/AdminController.java
@@ -13,9 +13,11 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Controller
+@RequestMapping("/admin")
 public class AdminController {
 
     private final ProductManagementService productManagementService;
@@ -24,7 +26,7 @@ public class AdminController {
         this.productManagementService = productManagementService;
     }
 
-    @GetMapping(value = {"/admin", "/admin/products"})
+    @GetMapping(value = {"", "/products"})
     @ResponseStatus(HttpStatus.OK)
     public String readProducts(final Model model) {
         final List<ProductDto> allProduct = productManagementService.findAllProduct();
@@ -32,21 +34,22 @@ public class AdminController {
         return "admin";
     }
 
-    @PostMapping("/admin/products")
+    @PostMapping("/products")
     @ResponseStatus(HttpStatus.CREATED)
     public void createProduct(@RequestBody @Valid final ProductDto productDto) {
         productManagementService.addProduct(productDto);
     }
 
-    @PatchMapping("/admin/products/{product_id}")
+    @PatchMapping("/products/{product_id}")
     @ResponseStatus(HttpStatus.CREATED)
-    public void updateProduct(@PathVariable("product_id") final Long id, @RequestBody @Valid final ProductDto productDto) {
+    public void updateProduct(@PathVariable("product_id") final Long id,
+                              @RequestBody @Valid final ProductDto productDto) {
         final ProductDto updatedProductDto
                 = new ProductDto(id, productDto.getName(), productDto.getImageUrl(), productDto.getPrice());
         productManagementService.updateProduct(updatedProductDto);
     }
 
-    @DeleteMapping("/admin/products/{product_id}")
+    @DeleteMapping("/products/{product_id}")
     @ResponseStatus(HttpStatus.OK)
     public void deleteProduct(@PathVariable("product_id") final Long id) {
         productManagementService.deleteProduct(id);

--- a/src/main/java/cart/controller/AdminController.java
+++ b/src/main/java/cart/controller/AdminController.java
@@ -27,7 +27,6 @@ public class AdminController {
     }
 
     @GetMapping(value = {"", "/products"})
-    @ResponseStatus(HttpStatus.OK)
     public String readProducts(final Model model) {
         final List<ProductDto> allProduct = productManagementService.findAllProduct();
         model.addAttribute("products", allProduct);

--- a/src/main/java/cart/controller/AdminController.java
+++ b/src/main/java/cart/controller/AdminController.java
@@ -3,6 +3,7 @@ package cart.controller;
 import cart.dto.ProductDto;
 import cart.service.ProductManagementService;
 import java.util.List;
+import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -33,13 +34,13 @@ public class AdminController {
 
     @PostMapping("/admin/products")
     @ResponseStatus(HttpStatus.CREATED)
-    public void createProduct(@RequestBody final ProductDto productDto) {
+    public void createProduct(@RequestBody @Valid final ProductDto productDto) {
         productManagementService.addProduct(productDto);
     }
 
     @PatchMapping("/admin/products/{product_id}")
     @ResponseStatus(HttpStatus.CREATED)
-    public void updateProduct(@PathVariable("product_id") final Long id, @RequestBody final ProductDto productDto) {
+    public void updateProduct(@PathVariable("product_id") final Long id, @RequestBody @Valid final ProductDto productDto) {
         final ProductDto updatedProductDto
                 = new ProductDto(id, productDto.getName(), productDto.getImageUrl(), productDto.getPrice());
         productManagementService.updateProduct(updatedProductDto);

--- a/src/main/java/cart/controller/AdminController.java
+++ b/src/main/java/cart/controller/AdminController.java
@@ -1,6 +1,8 @@
 package cart.controller;
 
+import cart.dto.CreateProductRequest;
 import cart.dto.ProductDto;
+import cart.dto.UpdateProductRequest;
 import cart.service.ProductManagementService;
 import java.util.List;
 import javax.validation.Valid;
@@ -35,17 +37,15 @@ public class AdminController {
 
     @PostMapping("/products")
     @ResponseStatus(HttpStatus.CREATED)
-    public void createProduct(@RequestBody @Valid final ProductDto productDto) {
-        productManagementService.addProduct(productDto);
+    public void createProduct(@RequestBody @Valid final CreateProductRequest request) {
+        productManagementService.addProduct(request);
     }
 
     @PatchMapping("/products/{product_id}")
     @ResponseStatus(HttpStatus.CREATED)
     public void updateProduct(@PathVariable("product_id") final Long id,
-                              @RequestBody @Valid final ProductDto productDto) {
-        final ProductDto updatedProductDto
-                = new ProductDto(id, productDto.getName(), productDto.getImageUrl(), productDto.getPrice());
-        productManagementService.updateProduct(updatedProductDto);
+                              @RequestBody @Valid final UpdateProductRequest request) {
+        productManagementService.updateProduct(id, request);
     }
 
     @DeleteMapping("/products/{product_id}")

--- a/src/main/java/cart/controller/ExceptionResponse.java
+++ b/src/main/java/cart/controller/ExceptionResponse.java
@@ -1,0 +1,20 @@
+package cart.controller;
+
+public class ExceptionResponse {
+
+    private final int statusCode;
+    private final String message;
+
+    public ExceptionResponse(final int statusCode, final String message) {
+        this.statusCode = statusCode;
+        this.message = message;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/cart/controller/ProductController.java
+++ b/src/main/java/cart/controller/ProductController.java
@@ -1,0 +1,28 @@
+package cart.controller;
+
+import cart.dto.ProductDto;
+import cart.service.ProductManagementService;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Controller
+public class ProductController {
+
+    private final ProductManagementService productManagementService;
+
+    public ProductController(final ProductManagementService productManagementService) {
+        this.productManagementService = productManagementService;
+    }
+
+    @GetMapping("/")
+    @ResponseStatus(HttpStatus.OK)
+    public String readProducts(final Model model) {
+        final List<ProductDto> allProduct = productManagementService.findAllProduct();
+        model.addAttribute("products", allProduct);
+        return "index";
+    }
+}

--- a/src/main/java/cart/controller/ProductExceptionHandler.java
+++ b/src/main/java/cart/controller/ProductExceptionHandler.java
@@ -1,0 +1,29 @@
+package cart.controller;
+
+import java.util.stream.Collectors;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class ProductExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> handleInvalidException(final MethodArgumentNotValidException e) {
+        final String errorMessage = e.getFieldErrors().stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.joining(", "));
+        return ResponseEntity.badRequest().body(
+                new ExceptionResponse(HttpStatus.BAD_REQUEST.value(), errorMessage));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleUnexpectedException(final Exception e) {
+        System.out.println(e.getClass());
+        return ResponseEntity.internalServerError().body(
+                new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage()));
+    }
+}

--- a/src/main/java/cart/domain/ImageUrl.java
+++ b/src/main/java/cart/domain/ImageUrl.java
@@ -1,0 +1,40 @@
+package cart.domain;
+
+import java.util.Objects;
+
+public class ImageUrl {
+
+    private final String value;
+
+    public ImageUrl(final String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(final String value) {
+        if (value.isBlank()) {
+            throw new IllegalArgumentException("이미지 경로는 공백일 수 없습니다.");
+        }
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ImageUrl imageUrl = (ImageUrl) o;
+        return Objects.equals(value, imageUrl.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/src/main/java/cart/domain/Name.java
+++ b/src/main/java/cart/domain/Name.java
@@ -1,0 +1,40 @@
+package cart.domain;
+
+import java.util.Objects;
+
+public class Name {
+
+    private final String value;
+
+    public Name(final String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(final String value) {
+        if (value.isBlank()) {
+            throw new IllegalArgumentException("이름은 공백일 수 없습니다.");
+        }
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final Name name = (Name) o;
+        return Objects.equals(value, name.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/src/main/java/cart/domain/Price.java
+++ b/src/main/java/cart/domain/Price.java
@@ -1,0 +1,43 @@
+package cart.domain;
+
+import java.util.Objects;
+
+public class Price {
+
+    private static final int LOWER_BOUND = 0;
+    private static final int UPPER_BOUND = 1_000_000_000;
+
+    private final int value;
+
+    public Price(final int value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(final int value) {
+        if (value < LOWER_BOUND || value > UPPER_BOUND) {
+            throw new IllegalArgumentException("가격은 10억 이하의 음이 아닌 정수여야 합니다.");
+        }
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final Price price = (Price) o;
+        return value == price.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/src/main/java/cart/domain/Product.java
+++ b/src/main/java/cart/domain/Product.java
@@ -1,0 +1,26 @@
+package cart.domain;
+
+public class Product {
+
+    private final Name name;
+    private final ImageUrl imageUrl;
+    private final Price price;
+
+    public Product(final String name, final String imageUrl, final Integer price) {
+        this.name = new Name(name);
+        this.imageUrl = new ImageUrl(imageUrl);
+        this.price = new Price(price);
+    }
+
+    public Name getName() {
+        return name;
+    }
+
+    public ImageUrl getImageUrl() {
+        return imageUrl;
+    }
+
+    public Price getPrice() {
+        return price;
+    }
+}

--- a/src/main/java/cart/dto/CreateProductRequest.java
+++ b/src/main/java/cart/dto/CreateProductRequest.java
@@ -1,0 +1,34 @@
+package cart.dto;
+
+import javax.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Range;
+
+public class CreateProductRequest {
+
+    @NotBlank(message = "이름은 공백일 수 없습니다.")
+    private final String name;
+
+    @NotBlank(message = "이미지 경로는 공백일 수 없습니다.")
+    private final String imageUrl;
+
+    @Range(min = 0, max = 1_000_000_000, message = "가격은 10억 이하의 음이 아닌 정수여야 합니다.")
+    private final int price;
+
+    public CreateProductRequest(final String name, final String imageUrl, final int price) {
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.price = price;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+}

--- a/src/main/java/cart/dto/ProductDto.java
+++ b/src/main/java/cart/dto/ProductDto.java
@@ -4,10 +4,13 @@ import cart.repository.entity.ProductEntity;
 
 public class ProductDto {
 
-    private final Long id;
-    private final String name;
-    private final String imageUrl;
-    private final int price;
+    private Long id;
+    private String name;
+    private String imageUrl;
+    private int price;
+
+    public ProductDto() {
+    }
 
     public ProductDto(final Long id, final String name, final String imageUrl, final int price) {
         this.id = id;

--- a/src/main/java/cart/dto/ProductDto.java
+++ b/src/main/java/cart/dto/ProductDto.java
@@ -1,0 +1,46 @@
+package cart.dto;
+
+import cart.repository.entity.ProductEntity;
+
+public class ProductDto {
+
+    private final Long id;
+    private final String name;
+    private final String imageUrl;
+    private final int price;
+
+    public ProductDto(final Long id, final String name, final String imageUrl, final int price) {
+        this.id = id;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.price = price;
+    }
+
+    public ProductDto(final String name, final String imageUrl, final int price) {
+        this(null, name, imageUrl, price);
+    }
+
+    public static ProductDto from(final ProductEntity productEntity) {
+        return new ProductDto(
+                productEntity.getId(),
+                productEntity.getName(),
+                productEntity.getImageUrl(),
+                productEntity.getPrice());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+}

--- a/src/main/java/cart/dto/ProductDto.java
+++ b/src/main/java/cart/dto/ProductDto.java
@@ -1,34 +1,19 @@
 package cart.dto;
 
 import cart.repository.entity.ProductEntity;
-import javax.validation.constraints.NotBlank;
-import org.hibernate.validator.constraints.Range;
 
 public class ProductDto {
 
     private Long id;
-
-    @NotBlank(message = "이름은 공백일 수 없습니다.")
     private String name;
-
-    @NotBlank(message = "이미지 경로는 공백일 수 없습니다.")
     private String imageUrl;
-
-    @Range(min = 0, max = 1_000_000_000 ,message = "가격은 10억 이하의 음이 아닌 정수여야 합니다.")
     private int price;
 
-    public ProductDto() {
-    }
-
-    public ProductDto(final Long id, final String name, final String imageUrl, final int price) {
+    private ProductDto(final Long id, final String name, final String imageUrl, final int price) {
         this.id = id;
         this.name = name;
         this.imageUrl = imageUrl;
         this.price = price;
-    }
-
-    public ProductDto(final String name, final String imageUrl, final int price) {
-        this(null, name, imageUrl, price);
     }
 
     public static ProductDto from(final ProductEntity productEntity) {

--- a/src/main/java/cart/dto/ProductDto.java
+++ b/src/main/java/cart/dto/ProductDto.java
@@ -1,12 +1,22 @@
 package cart.dto;
 
 import cart.repository.entity.ProductEntity;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.PositiveOrZero;
 
 public class ProductDto {
 
     private Long id;
+
+    @NotBlank(message = "이름은 공백일 수 없습니다.")
     private String name;
+
+    @NotBlank(message = "이미지 경로는 공백일 수 없습니다.")
     private String imageUrl;
+
+    @PositiveOrZero(message = "가격은 10억 이하의 음이 아닌 정수여야 합니다.")
+    @Max(value = 1_000_000_000, message = "가격은 10억 이하의 음이 아닌 정수여야 합니다.")
     private int price;
 
     public ProductDto() {

--- a/src/main/java/cart/dto/ProductDto.java
+++ b/src/main/java/cart/dto/ProductDto.java
@@ -1,9 +1,8 @@
 package cart.dto;
 
 import cart.repository.entity.ProductEntity;
-import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.PositiveOrZero;
+import org.hibernate.validator.constraints.Range;
 
 public class ProductDto {
 
@@ -15,8 +14,7 @@ public class ProductDto {
     @NotBlank(message = "이미지 경로는 공백일 수 없습니다.")
     private String imageUrl;
 
-    @PositiveOrZero(message = "가격은 10억 이하의 음이 아닌 정수여야 합니다.")
-    @Max(value = 1_000_000_000, message = "가격은 10억 이하의 음이 아닌 정수여야 합니다.")
+    @Range(min = 0, max = 1_000_000_000 ,message = "가격은 10억 이하의 음이 아닌 정수여야 합니다.")
     private int price;
 
     public ProductDto() {

--- a/src/main/java/cart/dto/UpdateProductRequest.java
+++ b/src/main/java/cart/dto/UpdateProductRequest.java
@@ -1,0 +1,34 @@
+package cart.dto;
+
+import javax.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Range;
+
+public class UpdateProductRequest {
+
+    @NotBlank(message = "이름은 공백일 수 없습니다.")
+    private final String name;
+
+    @NotBlank(message = "이미지 경로는 공백일 수 없습니다.")
+    private final String imageUrl;
+
+    @Range(min = 0, max = 1_000_000_000, message = "가격은 10억 이하의 음이 아닌 정수여야 합니다.")
+    private final int price;
+
+    public UpdateProductRequest(final String name, final String imageUrl, final int price) {
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.price = price;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+}

--- a/src/main/java/cart/exception/ExceptionResponse.java
+++ b/src/main/java/cart/exception/ExceptionResponse.java
@@ -1,4 +1,4 @@
-package cart.controller;
+package cart.exception;
 
 public class ExceptionResponse {
 

--- a/src/main/java/cart/exception/ProductExceptionHandler.java
+++ b/src/main/java/cart/exception/ProductExceptionHandler.java
@@ -1,4 +1,4 @@
-package cart.controller;
+package cart.exception;
 
 import java.util.stream.Collectors;
 import org.springframework.context.support.DefaultMessageSourceResolvable;

--- a/src/main/java/cart/exception/ProductExceptionHandler.java
+++ b/src/main/java/cart/exception/ProductExceptionHandler.java
@@ -2,6 +2,7 @@ package cart.exception;
 
 import java.util.stream.Collectors;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -12,18 +13,27 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class ProductExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ExceptionResponse> handleInvalidException(final MethodArgumentNotValidException e) {
+    public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
         final String errorMessage = e.getFieldErrors().stream()
                 .map(DefaultMessageSourceResolvable::getDefaultMessage)
                 .collect(Collectors.joining(", "));
-        return ResponseEntity.badRequest().body(
-                new ExceptionResponse(HttpStatus.BAD_REQUEST.value(), errorMessage));
+
+        return ResponseEntity
+                .badRequest()
+                .body(new ExceptionResponse(HttpStatus.BAD_REQUEST.value(), errorMessage));
+    }
+
+    @ExceptionHandler(EmptyResultDataAccessException.class)
+    public ResponseEntity<ExceptionResponse> handleEmptyResultDataAccessException(final EmptyResultDataAccessException e) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(new ExceptionResponse(HttpStatus.NOT_FOUND.value(), e.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleUnexpectedException(final Exception e) {
-        System.out.println(e.getClass());
-        return ResponseEntity.internalServerError().body(
-                new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage()));
+        return ResponseEntity
+                .internalServerError()
+                .body(new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage()));
     }
 }

--- a/src/main/java/cart/repository/dao/InMemoryProductDao.java
+++ b/src/main/java/cart/repository/dao/InMemoryProductDao.java
@@ -5,9 +5,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public class InMemoryProductDao implements ProductDao {
 
     private final List<ProductEntity> productEntities = new LinkedList<>();

--- a/src/main/java/cart/repository/dao/InMemoryProductDao.java
+++ b/src/main/java/cart/repository/dao/InMemoryProductDao.java
@@ -1,0 +1,61 @@
+package cart.repository.dao;
+
+import cart.repository.entity.ProductEntity;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryProductDao implements ProductDao {
+
+    private final List<ProductEntity> productEntities = new LinkedList<>();
+
+    @Override
+    public Long save(final ProductEntity productEntity) {
+        final String name = productEntity.getName();
+        final String imageUrl = productEntity.getImageUrl();
+        final int price = productEntity.getPrice();
+
+        if (productEntities.isEmpty()) {
+            final Long id = 1L;
+            productEntities.add(new ProductEntity(id, name, imageUrl, price));
+            return id;
+        }
+
+        final int lastIndex = productEntities.size() - 1;
+        final Long id = productEntities.get(lastIndex).getId() + 1;
+        productEntities.add(new ProductEntity(id, name, imageUrl, price));
+        return id;
+    }
+
+    @Override
+    public List<ProductEntity> findAll() {
+        return new ArrayList<>(productEntities);
+    }
+
+    @Override
+    public int update(final ProductEntity productEntity) {
+        final Long id = productEntity.getId();
+        final int index = removeProductByIdAndReturnIndex(id);
+        productEntities.add(index, productEntity);
+        return 1;
+    }
+
+    private int removeProductByIdAndReturnIndex(final Long id) {
+        for (int i = 0; i < productEntities.size(); i++) {
+            final ProductEntity productEntity = productEntities.get(i);
+            if (productEntity.getId().equals(id)) {
+                productEntities.remove(i);
+                return i;
+            }
+        }
+        throw new IllegalArgumentException("해당 id가 존재하지 않습니다.");
+    }
+
+    @Override
+    public int delete(final Long id) {
+        removeProductByIdAndReturnIndex(id);
+        return 1;
+    }
+}

--- a/src/main/java/cart/repository/dao/InMemoryProductDao.java
+++ b/src/main/java/cart/repository/dao/InMemoryProductDao.java
@@ -4,6 +4,7 @@ import cart.repository.entity.ProductEntity;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -50,7 +51,7 @@ public class InMemoryProductDao implements ProductDao {
                 return i;
             }
         }
-        throw new IllegalArgumentException("해당 id가 존재하지 않습니다.");
+        throw new EmptyResultDataAccessException("해당 id가 존재하지 않습니다.", 1);
     }
 
     @Override

--- a/src/main/java/cart/repository/dao/JdbcProductDao.java
+++ b/src/main/java/cart/repository/dao/JdbcProductDao.java
@@ -1,0 +1,62 @@
+package cart.repository.dao;
+
+import cart.repository.entity.ProductEntity;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcProductDao implements ProductDao {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private final RowMapper<ProductEntity> actorRowMapper = (resultSet, rowNum) -> new ProductEntity(
+            resultSet.getLong("product_id"),
+            resultSet.getString("name"),
+            resultSet.getString("image_url"),
+            resultSet.getInt("price")
+    );
+
+    public JdbcProductDao(final JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public Long save(final ProductEntity productEntity) {
+        final String sql = "INSERT INTO product (name, image_url, price) VALUES (?, ?, ?)";
+        final GeneratedKeyHolder keyHolder = new GeneratedKeyHolder();
+
+        jdbcTemplate.update(connection -> {
+            final PreparedStatement preparedStatement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            preparedStatement.setString(1, productEntity.getName());
+            preparedStatement.setString(2, productEntity.getImageUrl());
+            preparedStatement.setInt(3, productEntity.getPrice());
+            return preparedStatement;
+        }, keyHolder);
+
+        return Objects.requireNonNull(keyHolder.getKey()).longValue();
+    }
+
+    @Override
+    public List<ProductEntity> findAll() {
+        final String sql = "SELECT product_id, name, image_url, price FROM product";
+        return jdbcTemplate.query(sql, actorRowMapper);
+    }
+
+    @Override
+    public int update(final ProductEntity productEntity) {
+        final String sql = "UPDATE product SET name = ?, image_url = ?, price = ?";
+        return jdbcTemplate.update(sql, productEntity.getName(), productEntity.getImageUrl(), productEntity.getPrice());
+    }
+
+    @Override
+    public int delete(final Long id) {
+        final String sql = "DELETE FROM product WHERE product_id = ?";
+        return jdbcTemplate.update(sql, id);
+    }
+}

--- a/src/main/java/cart/repository/dao/ProductDao.java
+++ b/src/main/java/cart/repository/dao/ProductDao.java
@@ -1,0 +1,15 @@
+package cart.repository.dao;
+
+import cart.repository.entity.ProductEntity;
+import java.util.List;
+
+public interface ProductDao {
+
+    Long save(final ProductEntity productEntity);
+
+    List<ProductEntity> findAll();
+
+    int update(final ProductEntity productEntity);
+
+    int delete(final Long id);
+}

--- a/src/main/java/cart/repository/entity/ProductEntity.java
+++ b/src/main/java/cart/repository/entity/ProductEntity.java
@@ -1,6 +1,6 @@
 package cart.repository.entity;
 
-import cart.dto.ProductDto;
+import cart.domain.Product;
 
 public class ProductEntity {
 
@@ -20,12 +20,19 @@ public class ProductEntity {
         this(null, name, imageUrl, price);
     }
 
-    public static ProductEntity from(final ProductDto productDto) {
+    public static ProductEntity from(final Product product) {
         return new ProductEntity(
-                productDto.getId(),
-                productDto.getName(),
-                productDto.getImageUrl(),
-                productDto.getPrice());
+                product.getName().getValue(),
+                product.getImageUrl().getValue(),
+                product.getPrice().getValue());
+    }
+
+    public static ProductEntity of(final Long id, final Product product) {
+        return new ProductEntity(
+                id,
+                product.getName().getValue(),
+                product.getImageUrl().getValue(),
+                product.getPrice().getValue());
     }
 
     public Long getId() {

--- a/src/main/java/cart/repository/entity/ProductEntity.java
+++ b/src/main/java/cart/repository/entity/ProductEntity.java
@@ -1,5 +1,7 @@
 package cart.repository.entity;
 
+import cart.dto.ProductDto;
+
 public class ProductEntity {
 
     private final Long id;
@@ -16,6 +18,14 @@ public class ProductEntity {
 
     public ProductEntity(final String name, final String imageUrl, final int price) {
         this(null, name, imageUrl, price);
+    }
+
+    public static ProductEntity from(final ProductDto productDto) {
+        return new ProductEntity(
+                productDto.getId(),
+                productDto.getName(),
+                productDto.getImageUrl(),
+                productDto.getPrice());
     }
 
     public Long getId() {

--- a/src/main/java/cart/repository/entity/ProductEntity.java
+++ b/src/main/java/cart/repository/entity/ProductEntity.java
@@ -1,0 +1,36 @@
+package cart.repository.entity;
+
+public class ProductEntity {
+
+    private final Long id;
+    private final String name;
+    private final String imageUrl;
+    private final int price;
+
+    public ProductEntity(final Long id, final String name, final String imageUrl, final int price) {
+        this.id = id;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.price = price;
+    }
+
+    public ProductEntity(final String name, final String imageUrl, final int price) {
+        this(null, name, imageUrl, price);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+}

--- a/src/main/java/cart/service/ProductManagementService.java
+++ b/src/main/java/cart/service/ProductManagementService.java
@@ -1,0 +1,36 @@
+package cart.service;
+
+import cart.dto.ProductDto;
+import cart.repository.dao.ProductDao;
+import cart.repository.entity.ProductEntity;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProductManagementService {
+
+    private final ProductDao productDao;
+
+    public ProductManagementService(final ProductDao productDao) {
+        this.productDao = productDao;
+    }
+
+    public void addProduct(final ProductDto productDto) {
+        productDao.save(ProductEntity.from(productDto));
+    }
+
+    public List<ProductDto> findAllProduct() {
+        return productDao.findAll().stream()
+                .map(ProductDto::from)
+                .collect(Collectors.toList());
+    }
+
+    public void updateProduct(final ProductDto productDto) {
+        productDao.update(ProductEntity.from(productDto));
+    }
+
+    public void deleteProduct(final Long id) {
+        productDao.delete(id);
+    }
+}

--- a/src/main/java/cart/service/ProductManagementService.java
+++ b/src/main/java/cart/service/ProductManagementService.java
@@ -9,7 +9,9 @@ import cart.repository.entity.ProductEntity;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @Service
 public class ProductManagementService {
 

--- a/src/main/java/cart/service/ProductManagementService.java
+++ b/src/main/java/cart/service/ProductManagementService.java
@@ -1,6 +1,9 @@
 package cart.service;
 
+import cart.domain.Product;
+import cart.dto.CreateProductRequest;
 import cart.dto.ProductDto;
+import cart.dto.UpdateProductRequest;
 import cart.repository.dao.ProductDao;
 import cart.repository.entity.ProductEntity;
 import java.util.List;
@@ -16,8 +19,9 @@ public class ProductManagementService {
         this.productDao = productDao;
     }
 
-    public void addProduct(final ProductDto productDto) {
-        productDao.save(ProductEntity.from(productDto));
+    public void addProduct(final CreateProductRequest request) {
+        final Product product = new Product(request.getName(), request.getImageUrl(), request.getPrice());
+        productDao.save(ProductEntity.from(product));
     }
 
     public List<ProductDto> findAllProduct() {
@@ -26,8 +30,9 @@ public class ProductManagementService {
                 .collect(Collectors.toList());
     }
 
-    public void updateProduct(final ProductDto productDto) {
-        productDao.update(ProductEntity.from(productDto));
+    public void updateProduct(final Long id, final UpdateProductRequest request) {
+        final Product product = new Product(request.getName(), request.getImageUrl(), request.getPrice());
+        productDao.update(ProductEntity.of(id, product));
     }
 
     public void deleteProduct(final Long id) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL
+spring.datasource.driver-class-name=org.h2.Driver

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS product
+(
+    product_id BIGINT      NOT NULL AUTO_INCREMENT,
+    name       VARCHAR(50) NOT NULL,
+    image_url  VARCHAR(255),
+    price      INT         NOT NULL,
+    PRIMARY KEY (product_id)
+);

--- a/src/main/resources/static/js/admin.js
+++ b/src/main/resources/static/js/admin.js
@@ -47,7 +47,13 @@ form.addEventListener('submit', (event) => {
 // TODO: [1단계] 상품 관리 CRUD API에 맞게 변경
 const createProduct = (product) => {
     axios.request({
-        url: '',
+        method: 'post',
+        url: '/admin/products',
+        data: {
+            name: product.name,
+            imageUrl: product.imageUrl,
+            price: product.price
+        }
     }).then((response) => {
         window.location.reload();
     }).catch((error) => {
@@ -60,7 +66,13 @@ const updateProduct = (product) => {
     const { id } = product;
 
     axios.request({
-        url: '',
+        method: "patch",
+        url: '/admin/products/' + id,
+        data: {
+            name: product.name,
+            imageUrl: product.imageUrl,
+            price: product.price
+        }
     }).then((response) => {
         window.location.reload();
     }).catch((error) => {
@@ -71,7 +83,8 @@ const updateProduct = (product) => {
 // TODO: [1단계] 상품 관리 CRUD API에 맞게 변경
 const deleteProduct = (id) => {
     axios.request({
-        url: '',
+        method: "delete",
+        url: '/admin/products/' + id
     }).then((response) => {
         window.location.reload();
     }).catch((error) => {

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -34,10 +34,10 @@
             <!-- TODO: [1단계] 상품 정보에 맞게 변경 -->
             <tr th:each="product : ${products}">
                 <td th:text="${product.id}"></td>
-                <td></td> <!-- 상품 이름 -->
-                <td></td> <!-- 상품 가격 -->
+                <td th:text="${product.name}"></td> <!-- 상품 이름 -->
+                <td th:text="${product.price}"></td> <!-- 상품 가격 -->
                 <td>
-                    <img style="max-width: 100px;"> <!-- 상품 이미지 -->
+                    <img th:src="${product.imageUrl}" style="max-width: 100px;"> <!-- 상품 이미지 -->
                 </td>
                 <td>
                     <button th:onclick="showEditModal([[${product}]])">수정</button>
@@ -53,13 +53,13 @@
             <!-- TODO: [1단계] 상품 정보에 맞게 변경 -->
             <form id="form">
                 <label for="name">상품명</label><br>
-                <input type="text" id="name" name="" required><br>
+                <input type="text" id="name" name="name" required><br>
 
                 <label for="price">가격</label><br>
-                <input type="number" id="price" name="" required><br>
+                <input type="number" id="price" name="price" required><br>
 
                 <label for="image-url">이미지 URL</label><br>
-                <input type="text" id="image-url" name="" required><br>
+                <input type="text" id="image-url" name="imageUrl" required><br>
 
                 <button type="submit">제출</button>
             </form>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -23,12 +23,12 @@
         <!-- TODO: [1단계] 상품 정보에 맞게 변경 -->
         <li class="product" th:each="product : ${products}">
             <div class="product-image">
-                <img alt="상품 이미지"> <!-- 상품 이미지 -->
+                <img th:src="${product.imageUrl}" alt="상품 이미지"> <!-- 상품 이미지 -->
             </div>
             <div class="product-info">
                 <div class="product-desc">
-                    <p class="product-name"></p> <!-- 상품 이름 -->
-                    <p class="product-price"></p> <!-- 상품 가격 -->
+                    <p th:text="${product.name}" class="product-name"></p> <!-- 상품 이름 -->
+                    <p th:text="${product.price}" class="product-price"></p> <!-- 상품 가격 -->
                 </div>
                 <button type="submit" class="product-btn" th:onclick="addCartItem([[${product.id}]])">담기</button>
             </div>

--- a/src/test/java/cart/ProductIntegrationTest.java
+++ b/src/test/java/cart/ProductIntegrationTest.java
@@ -1,16 +1,20 @@
 package cart;
 
+import static io.restassured.RestAssured.given;
+
+import cart.dto.ProductDto;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.assertThat;
-
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class ProductIntegrationTest {
 
@@ -23,15 +27,64 @@ public class ProductIntegrationTest {
     }
 
     @Test
-    public void getProducts() {
-        var result = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .get("/products")
+    void 상품을_조회한다() {
+        given()
+                .when().get("/admin/products")
                 .then()
-                .extract();
-
-        assertThat(result.statusCode()).isEqualTo(HttpStatus.OK.value());
+                .statusCode(HttpStatus.OK.value());
     }
 
+    @Test
+    void 상품을_추가한다() {
+        final ProductDto productDto = new ProductDto("하디", "imageUrl", 10000);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(productDto)
+                .when().post("/admin/products")
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    void 상품을_업데이트한다() {
+        final ProductDto productDto = new ProductDto("하디", "image", 100000);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(productDto)
+                .when().post("/admin/products")
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+
+        final Long id = 1L;
+        final ProductDto updatedProductDto = new ProductDto("코코닥", "imageUrl", 10000);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(updatedProductDto)
+                .when().patch("/admin/products/{product_id}", id)
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    void 상품을_삭제한다() {
+        final ProductDto productDto = new ProductDto("하디", "image", 100000);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(productDto)
+                .when().post("/admin/products")
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+
+        final Long id = 1L;
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().delete("/admin/products/{product_id}", id)
+                .then()
+                .statusCode(HttpStatus.OK.value());
+    }
 }

--- a/src/test/java/cart/ProductIntegrationTest.java
+++ b/src/test/java/cart/ProductIntegrationTest.java
@@ -2,12 +2,17 @@ package cart;
 
 import static io.restassured.RestAssured.given;
 
-import cart.dto.ProductDto;
+import cart.domain.Product;
+import cart.dto.CreateProductRequest;
+import cart.dto.UpdateProductRequest;
+import cart.repository.dao.ProductDao;
+import cart.repository.entity.ProductEntity;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
@@ -17,6 +22,9 @@ import org.springframework.http.MediaType;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class ProductIntegrationTest {
+
+    @Autowired
+    private ProductDao productDao;
 
     @LocalServerPort
     private int port;
@@ -36,11 +44,11 @@ public class ProductIntegrationTest {
 
     @Test
     void 상품을_추가한다() {
-        final ProductDto productDto = new ProductDto("하디", "imageUrl", 10000);
+        final CreateProductRequest request = new CreateProductRequest("하디", "imageUrl", 10000);
 
         given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(productDto)
+                .body(request)
                 .when().post("/admin/products")
                 .then()
                 .statusCode(HttpStatus.CREATED.value());
@@ -48,21 +56,14 @@ public class ProductIntegrationTest {
 
     @Test
     void 상품을_업데이트한다() {
-        final ProductDto productDto = new ProductDto("하디", "image", 100000);
-
-        given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(productDto)
-                .when().post("/admin/products")
-                .then()
-                .statusCode(HttpStatus.CREATED.value());
+        productDao.save(ProductEntity.from(new Product("하디", "imageUrl", 100000)));
 
         final Long id = 1L;
-        final ProductDto updatedProductDto = new ProductDto("코코닥", "imageUrl", 10000);
+        final UpdateProductRequest request = new UpdateProductRequest("코코닥", "imageUrl", 10000);
 
         given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(updatedProductDto)
+                .body(request)
                 .when().patch("/admin/products/{product_id}", id)
                 .then()
                 .statusCode(HttpStatus.CREATED.value());
@@ -70,14 +71,7 @@ public class ProductIntegrationTest {
 
     @Test
     void 상품을_삭제한다() {
-        final ProductDto productDto = new ProductDto("하디", "image", 100000);
-
-        given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(productDto)
-                .when().post("/admin/products")
-                .then()
-                .statusCode(HttpStatus.CREATED.value());
+        productDao.save(ProductEntity.from(new Product("하디", "imageUrl", 100000)));
 
         final Long id = 1L;
 

--- a/src/test/java/cart/controller/AdminControllerTest.java
+++ b/src/test/java/cart/controller/AdminControllerTest.java
@@ -11,7 +11,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import cart.dto.CreateProductRequest;
 import cart.dto.ProductDto;
+import cart.dto.UpdateProductRequest;
 import cart.service.ProductManagementService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
@@ -53,8 +55,8 @@ public class AdminControllerTest {
 
     @Test
     void 상품을_추가한다() throws Exception {
-        final ProductDto productDto = new ProductDto("하디", "imageUrl", 100000);
-        final String requestBody = objectMapper.writeValueAsString(productDto);
+        final CreateProductRequest request = new CreateProductRequest("하디", "imageUrl", 100000);
+        final String requestBody = objectMapper.writeValueAsString(request);
         doNothing()
                 .when(productManagementService)
                 .addProduct(any());
@@ -68,11 +70,11 @@ public class AdminControllerTest {
     @Test
     void 상품을_업데이트한다() throws Exception {
         final Long id = 1L;
-        final ProductDto updatedProductDto = new ProductDto("코코닥", "imageUrl", 15000);
-        final String requestBody = objectMapper.writeValueAsString(updatedProductDto);
+        final UpdateProductRequest request = new UpdateProductRequest("코코닥", "imageUrl", 15000);
+        final String requestBody = objectMapper.writeValueAsString(request);
         doNothing()
                 .when(productManagementService)
-                .updateProduct(any());
+                .updateProduct(any(), any());
 
         mockMvc.perform(patch("/admin/products/{product_id}", id)
                         .content(requestBody)

--- a/src/test/java/cart/controller/AdminControllerTest.java
+++ b/src/test/java/cart/controller/AdminControllerTest.java
@@ -1,0 +1,96 @@
+package cart.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import cart.dto.ProductDto;
+import cart.service.ProductManagementService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@WebMvcTest(AdminController.class)
+public class AdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ProductManagementService productManagementService;
+
+    @Test
+    void 어드민_페이지를_조회한다() throws Exception {
+        List<ProductDto> products = new ArrayList<>();
+        given(productManagementService.findAllProduct())
+                .willReturn(products);
+
+        mockMvc.perform(get("/admin"))
+                .andExpect(model().attributeExists("products"))
+                .andExpect(model().attribute("products", products))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 상품을_추가한다() throws Exception {
+        final ProductDto productDto = new ProductDto("하디", "imageUrl", 100000);
+        final String requestBody = objectMapper.writeValueAsString(productDto);
+        doNothing()
+                .when(productManagementService)
+                .addProduct(any());
+
+        mockMvc.perform(post("/admin/products")
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void 상품을_업데이트한다() throws Exception {
+        final Long id = 1L;
+        final ProductDto updatedProductDto = new ProductDto("코코닥", "imageUrl", 15000);
+        final String requestBody = objectMapper.writeValueAsString(updatedProductDto);
+        doNothing()
+                .when(productManagementService)
+                .updateProduct(any());
+
+        mockMvc.perform(patch("/admin/products/{product_id}", id)
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void 상품을_삭제한다() throws Exception {
+        final Long id = 1L;
+
+        final ProductDto productDto =  new ProductDto("  ", "woe", -100);
+
+        doNothing()
+                .when(productManagementService)
+                .deleteProduct(anyLong());
+
+        mockMvc.perform(delete("/admin/products/{product_id}", id))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/cart/controller/AdminControllerTest.java
+++ b/src/test/java/cart/controller/AdminControllerTest.java
@@ -84,8 +84,6 @@ public class AdminControllerTest {
     void 상품을_삭제한다() throws Exception {
         final Long id = 1L;
 
-        final ProductDto productDto =  new ProductDto("  ", "woe", -100);
-
         doNothing()
                 .when(productManagementService)
                 .deleteProduct(anyLong());

--- a/src/test/java/cart/controller/ProductControllerTest.java
+++ b/src/test/java/cart/controller/ProductControllerTest.java
@@ -1,0 +1,42 @@
+package cart.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import cart.dto.ProductDto;
+import cart.service.ProductManagementService;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@WebMvcTest(ProductController.class)
+public class ProductControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProductManagementService productManagementService;
+
+    @Test
+    void 상품_목록_페이지를_조회한다() throws Exception {
+        List<ProductDto> products = new ArrayList<>();
+        given(productManagementService.findAllProduct())
+                .willReturn(products);
+
+        mockMvc.perform(get("/"))
+                .andExpect(model().attributeExists("products"))
+                .andExpect(model().attribute("products", products))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/cart/domain/ImageUrlTest.java
+++ b/src/test/java/cart/domain/ImageUrlTest.java
@@ -1,0 +1,21 @@
+package cart.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class ImageUrlTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   "})
+    void 이미지_경로는_공백일_수_없다(final String imageUrl) {
+        assertThatThrownBy(() -> new ImageUrl(imageUrl))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미지 경로는 공백일 수 없습니다.");
+    }
+}

--- a/src/test/java/cart/domain/NameTest.java
+++ b/src/test/java/cart/domain/NameTest.java
@@ -1,0 +1,21 @@
+package cart.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class NameTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   "})
+    void 이름은_공백일_수_없다(final String name) {
+        assertThatThrownBy(() -> new Name(name))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이름은 공백일 수 없습니다.");
+    }
+}

--- a/src/test/java/cart/domain/PriceTest.java
+++ b/src/test/java/cart/domain/PriceTest.java
@@ -1,0 +1,20 @@
+package cart.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class PriceTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 1000000001})
+    void 가격은_음수이거나_10억_초과일_수_없다(final Integer price) {
+        Assertions.assertThatThrownBy(() -> new Price(price))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("가격은 10억 이하의 음이 아닌 정수여야 합니다.");
+    }
+}

--- a/src/test/java/cart/repository/dao/InMemoryProductDaoTest.java
+++ b/src/test/java/cart/repository/dao/InMemoryProductDaoTest.java
@@ -1,0 +1,55 @@
+package cart.repository.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import cart.repository.entity.ProductEntity;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class InMemoryProductDaoTest {
+
+    InMemoryProductDao inMemoryProductDao;
+
+    @BeforeEach
+    void setUp() {
+        inMemoryProductDao = new InMemoryProductDao();
+    }
+
+    @Test
+    void 엔티티를_저장하고_조회한다() {
+        final ProductEntity firstProductEntity = new ProductEntity("kokodak", "localhost:8080/test", 1000);
+        final ProductEntity secondProductEntity = new ProductEntity("hardy", "localhost:8080/test", 1000);
+        inMemoryProductDao.save(firstProductEntity);
+        inMemoryProductDao.save(secondProductEntity);
+        final List<ProductEntity> products = inMemoryProductDao.findAll();
+        SoftAssertions softAssertions = new SoftAssertions();
+        softAssertions.assertThat(products.size()).isEqualTo(2);
+        softAssertions.assertThat(products.get(0).getName()).isEqualTo(firstProductEntity.getName());
+        softAssertions.assertThat(products.get(1).getName()).isEqualTo(secondProductEntity.getName());
+        softAssertions.assertAll();
+    }
+
+    @Test
+    void 엔티티를_업데이트한다() {
+        final ProductEntity productEntity = new ProductEntity("kokodak", "localhost:8080/test", 1000);
+        inMemoryProductDao.save(productEntity);
+        final ProductEntity updatedProductEntity = new ProductEntity(1L, "hardy", "localhost:8080/test", 2000);
+        inMemoryProductDao.update(updatedProductEntity);
+        final List<ProductEntity> products = inMemoryProductDao.findAll();
+        assertThat(products.get(0).getName()).isEqualTo(updatedProductEntity.getName());
+    }
+
+    @Test
+    void 엔티티를_삭제한다() {
+        final ProductEntity productEntity = new ProductEntity("kokodak", "localhost:8080/test", 1000);
+        inMemoryProductDao.save(productEntity);
+        inMemoryProductDao.delete(1L);
+        assertThat(inMemoryProductDao.findAll()).isEmpty();
+    }
+}

--- a/src/test/java/cart/repository/dao/JdbcProductDaoTest.java
+++ b/src/test/java/cart/repository/dao/JdbcProductDaoTest.java
@@ -1,0 +1,68 @@
+package cart.repository.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import cart.repository.entity.ProductEntity;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@JdbcTest
+public class JdbcProductDaoTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private ProductDao productDao;
+
+    @BeforeEach
+    void setUp() {
+        productDao = new JdbcProductDao(jdbcTemplate);
+    }
+
+    @Test
+    void 엔티티를_저장하고_조회한다() {
+        final ProductEntity firstProductEntity = new ProductEntity("kokodak", "localhost:8080/test", 1000);
+        final ProductEntity secondProductEntity = new ProductEntity("hardy", "localhost:8080/test", 1000);
+        productDao.save(firstProductEntity);
+        productDao.save(secondProductEntity);
+
+        final List<ProductEntity> products = productDao.findAll();
+
+        SoftAssertions softAssertions = new SoftAssertions();
+        softAssertions.assertThat(products.size()).isEqualTo(2);
+        softAssertions.assertThat(products.get(0).getName()).isEqualTo(firstProductEntity.getName());
+        softAssertions.assertThat(products.get(1).getName()).isEqualTo(secondProductEntity.getName());
+        softAssertions.assertAll();
+    }
+
+    @Test
+    void 엔티티를_업데이트한다() {
+        final ProductEntity productEntity = new ProductEntity("kokodak", "localhost:8080/test", 1000);
+        productDao.save(productEntity);
+        final ProductEntity updatedProductEntity = new ProductEntity(1L, "hardy", "localhost:8080/test", 2000);
+        productDao.update(updatedProductEntity);
+
+        final List<ProductEntity> products = productDao.findAll();
+
+        assertThat(products.get(0).getName()).isEqualTo(updatedProductEntity.getName());
+    }
+
+    @Test
+    void 엔티티를_삭제한다() {
+        final ProductEntity productEntity = new ProductEntity("kokodak", "localhost:8080/test", 1000);
+        productDao.save(productEntity);
+
+        productDao.delete(1L);
+
+        assertThat(productDao.findAll()).isEmpty();
+    }
+}


### PR DESCRIPTION
안녕하세요 럿고! 저는 코코닥이라고 합니다. 잘 부탁드려요 😁

아래에는 이번 미션을 진행하면서 들었던 생각과 질문들을 적었습니다! 리뷰해주셔서 감사합니다 럿고!

---

## 싱크홀 안티패턴의 문제

현재 계층 구조는 Controller → Service → DAO 로 설계가 되어있습니다. 

다만 코드를 작성하며 마음에 걸렸던 점은, 현재 서비스 내부 메서드에서 단순 DAO 메서드만 호출하는 상황때문에 불필요한 비용이 발생한다는 점이었습니다. 

그럼에도 서비스를 만들게 된 이유는, 서비스가 존재하지 않는다면 컨트롤러에서 DAO 로직을 직접적으로 다루어야 하는데, 차후 확장성을 고려했을 때 계층 간 관심사가 분리되지 않아 변화에 대응하기 어려운 구조가 될 것 같아 서비스를 만들게 되었습니다. 

또한, 현재 프로젝트 규모에서 싱크홀 안티패턴이 큰 문제가 될 것 같지 않을 것 같다는 이유 또한 고려되었습니다.

## 검증부 위치

현재 코드에서 값에 대한 검증부 위치는 DTO 내부에 있습니다.

제가 생각했을 때, 가격에 대한 검증 로직은 DTO에 대한 검증이라기보다는 사실 도메인이 검증해야 할 요소인 것 같았습니다.

그래서 “가격에 대한 VO 객체를 만들어서 해당 도메인이 검증 책임을 가지도록 할까?” 를 페어와 함께 고민했었는데, 내린 결론은 “검증만을 위한 도메인을 만드는 것은 불필요해보인다” 였습니다. 아직까지는 도메인 로직이 필요가 없어보여 정말 검증만을 위해 존재하는 것 같은 느낌이 들었습니다.

그래서 결국 모든 검증부의 위치를 DTO 내부로 들어가도록 만들게 되었습니다.

## 인메모리 DAO

DAO를 만들때, 인메모리 방식으로 만들어야 할 지, H2 데이터베이스를 사용하도록 만들어야 할 지 고민을 하다가 1단계 요구사항에서는 아직 데이터베이스에 대한 요구사항이 없어서 인메모리 방식의 DAO를 만들게 되었습니다.

## 테스트 코드

현재 만들어진 테스트 코드는 다음과 같습니다.

1. DAO에 대한 단위 테스트
2. 컨트롤러 계층에 대한 슬라이스 테스트
3. 통합 테스트

서비스 계층에 대한 슬라이스 테스트를 작성하지 않은 이유는, 현재 서비스의 구조가 단순 DAO 로직을 사용하는 방식이라, DAO에 대한 테스트가 되면 서비스 또한 함께 검증될 것 같다는 생각 때문이었습니다.

---

## 질문

1. 이번 미션에서부터 처음으로 `@Valid` 어노테이션을 활용하여 검증을 진행해봤는데, 보통 `@Valid` 는 컨트롤러 계층에서 역직렬화되어 넘어온 DTO 객체를 검증하는 데 사용된다고 알고 있습니다. 
    
    이번에 이 어노테이션을 적용해보며 궁금했던 점은, 어디까지가 DTO 객체에서 검증해야 할 부분이고, 어디까지가 도메인에서 검증해야 할 부분인지 헷갈렸던 것 같습니다. 
    
    이번 미션을 하며 제가 세운 기준은, 단순 입력 형식(공백은 허용하지 않는다, 몇 글자까지 가능하다)에 대한 검증은 DTO에서 하고, 조금 더 세부적인 정책(가격의 최대 값은 10억이다, 어떤 이름은 불가능하다)같은 경우는 도메인에서 검증해야 한다! 였습니다. 
    
    럿고는 보통 어떠한 기준을 가지고 검증부의 책임을 나누시나요?
    
2. 컨트롤러 계층에 대한 슬라이스 테스트를 진행할 때, “상품을 추가한다”, “상품을 수정한다” 와 같은 행위에 대한 결과를 제대로 테스트할 수가 없다는 느낌을 받았습니다.
    
    그냥 단순히 “어떤 API를 호출하면 어떤 응답코드를 반환한다” 정도의 테스트를 작성하게 되었는데, 뭔가 테스트에 대한 신뢰도가 낮은 느낌이었습니다.
    
    그래서 궁금했던 점은, 제가 아직 기술적인 역량이 부족해서 테스트를 할 수 있음에도 못한 것인지, 컨트롤러 계층의 테스트는 이런 식으로 진행돼도 괜찮은 것인지가 궁금합니다!
    
3. 레벨 1때는 메서드에 대한 단위 테스트를 최대한 독립적으로 작성해야한다고 배웠습니다. 예를 들면, “A 메서드에 대한 단위 테스트를 작성할 때는 B 메서드에 의존하면 안된다!” 와 같은 식이었습니다.
    
    하지만 이번 DAO 단위 테스트를 작성하면서 느꼈던 점은 저장, 수정, 삭제에 대한 단위 테스트를 하려면 공통적으로 조회 메서드에 의존해야한다는 점이었는데요. 또한 조회에 대한 테스트를 할때도 저장이 선행되어야하는 탓에 서로가 서로를 의존하는 형태의 테스트가 만들어지게 되었습니다.
    
    이런 경우에는 어떻게 테스트를 작성해야할까요? DAO 같은 경우에는 독립적으로 작성할 수 없는 특수한 케이스라고 받아들이는 것이 맞을까요!
    
4. 전체 통합 테스트 코드를 작성하면서, 상품을 수정하거나 삭제하는 테스트를 하려면 상품의 추가가 선행되어야했습니다. 
    
    그러다보니 상품을 추가하는 API를 RestAssured를 통해 추가적으로 호출하게 되었는데, 이런 방식의 테스트 작성이 괜찮을까요?!